### PR TITLE
Added support for easier layout selection

### DIFF
--- a/dist/web-greeter.yml
+++ b/dist/web-greeter.yml
@@ -33,6 +33,20 @@ greeter:
     time_language:
 
 #
+# layouts                  A list of preferred layouts to use
+#   - us                   "en_us" xkb layout
+#   - latam                "es_latam" xkb layout
+#   - gb dvorak            "en_gb_dvorak" xkb layout
+#
+# NOTE: See "man xkeyboard-config" for posible layout values. Also, see posible layouts here: https://web.archive.org/web/20161203032703/http://pastebin.com/v2vCPHjs
+# A layout value is composed in the main layout, like "us" or "latam", and its variant, like "dvorak", "colemak", "mac" or "mac_intl".
+# Separate the name and the variant with a space, like "gb dvorak"
+#
+layouts:
+    - us
+    - latam
+
+#
 # features:
 #     battery:             Enable greeter and themes to get battery status.
 #     backlight:

--- a/web-greeter/bridge/Config.py
+++ b/web-greeter/bridge/Config.py
@@ -32,6 +32,25 @@ from whither.bridge import (
     Variant,
 )
 
+import gi
+gi.require_version('LightDM', '1')
+from gi.repository import LightDM
+
+from . import (
+    layout_to_dict
+)
+
+def get_layouts(config_layouts: list[str]):
+    layouts = LightDM.get_layouts()
+    final_layouts: list[LightDM.Layout] = []
+    for ldm_lay in layouts:
+        for conf_lay in config_layouts:
+            if type(conf_lay) != str: return
+            conf_lay = conf_lay.replace(" ", "\t")
+            if ldm_lay.get_name() == conf_lay:
+                final_layouts.append(layout_to_dict(ldm_lay))
+    return final_layouts
+
 
 class Config(BridgeObject):
 
@@ -43,6 +62,7 @@ class Config(BridgeObject):
         self._branding = config.branding.as_dict()
         self._greeter = config.greeter.as_dict()
         self._features = config.features.as_dict()
+        self._layouts = get_layouts(config.layouts)
 
     @bridge.prop(Variant, notify=noop_signal)
     def branding(self):
@@ -55,3 +75,7 @@ class Config(BridgeObject):
     @bridge.prop(Variant, notify=noop_signal)
     def features(self):
         return self._features
+
+    @bridge.prop(Variant, notify=noop_signal)
+    def layouts(self):
+        return self._layouts

--- a/web-greeter/bridge/__init__.py
+++ b/web-greeter/bridge/__init__.py
@@ -97,11 +97,13 @@ def user_to_dict(user):
     if (not user):
         return dict()
     return dict(
+        background=user.get_background(),
         display_name=user.get_display_name(),
         home_directory=user.get_home_directory(),
         image=user.get_image(),
         language=user.get_language(),
         layout=user.get_layout(),
+        layouts=user.get_layouts(),
         logged_in=user.get_logged_in(),
         session=user.get_session(),
         username=user.get_name(),

--- a/web-greeter/globals.py
+++ b/web-greeter/globals.py
@@ -187,12 +187,14 @@ class WebGreeter(App):
         branding_config = ConfigLoader('branding', config_file).config
         greeter_config = ConfigLoader('greeter', config_file).config
         features_config = ConfigLoader('features', config_file).config
+        layouts_config = ConfigLoader('layouts', config_file).config
 
         greeter_config.update(custom_config["app"]["greeter"])
 
         self.config.branding.update(branding_config)
         self.config.greeter.update(greeter_config)
         self.config.features.update(features_config)
+        self.config.layouts = layouts_config
 
         cursor_theme = greeter_config["icon_theme"]
         os.environ["XCURSOR_THEME"] = cursor_theme if cursor_theme != None else getDefaultCursor()

--- a/web-greeter/whither.yml
+++ b/web-greeter/whither.yml
@@ -40,6 +40,9 @@ WebGreeter:
             theme: gruvbox
             icon_theme:
             time_language:
+        layouts:
+            - us
+            - latam
         features:
             battery: False
             backlight:


### PR DESCRIPTION
Closes #6

## Changes

- Adds `layouts` section in `/etc/lightdm/web-greeter.yml`
- Layouts accesible through `greeter_config.layouts`
    - Returns an array of `LightDM.Layout` objects, only if they are also inside `lightdm.layouts`

Setting the config like this:
```yaml
layouts:
  - us
  - latam
  - not valid layout
```

... will return:
```javascript
> greeter_config.layouts
[
  { name: "us",    description: "", ... },
  { name: "latam", description: "", ... }
]
```
