### PR TITLE
Terminate web-greeter gracefully

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -123,6 +123,7 @@ if __name__ == '__main__':
     from bridge import Greeter, Config, ThemeUtils
     from PyQt5.QtWidgets import QApplication
     from PyQt5.QtCore import Qt, QCoreApplication
+    from logger import logger
 
     QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
@@ -141,3 +142,6 @@ if __name__ == '__main__':
     # browser.load()
     browser.show()
     browser.run()
+
+    logger.debug("App closed")
+    sys.exit(0)

--- a/src/bridge/Greeter.py
+++ b/src/bridge/Greeter.py
@@ -93,6 +93,7 @@ class Greeter(BridgeObject):
         self._brightness_controller = BrightnessController()
 
         try:
+            LightDMGreeter.set_resettable(True)
             LightDMGreeter.connect_to_daemon_sync()
         except GError as err:
             logger.error(err)
@@ -367,6 +368,8 @@ class Greeter(BridgeObject):
 
     @Bridge.method(str, result=bool)
     def start_session(self, session):
+        from PyQt5.QtCore import QCoreApplication
+
         if not session.strip():
             return False
         try:
@@ -374,6 +377,7 @@ class Greeter(BridgeObject):
             if started or self.is_authenticated:
                 logger.debug("Session \"%s\" started", session)
                 screensaver.reset_screensaver()
+                QCoreApplication.quit() # Quit application after start_session
             return started
         except GError as err:
             logger.error(err)


### PR DESCRIPTION
Fixes #68

As we're gracefully quitting the Application after a successful start_session, the QWebEngineProfile is able to flush persistent data to disk (like LocalStorage).

## Changed

- LightDM is not set as resettable, so the greeter doesn't terminate immediately after a successful start_session.
- Gracefully quit Application after a successful start_session.

Here's a preview where I set `localStorage.setItem("Completed", "true");` before a `start_session`:

https://github.com/JezerM/web-greeter/assets/59768785/15b6dff2-9571-4027-8469-7c090c6537b6